### PR TITLE
Update tags for let-go language entry

### DIFF
--- a/src/dialects.yaml
+++ b/src/dialects.yaml
@@ -159,7 +159,7 @@
   repo: https://github.com/nooga/let-go
   host: Go
   fext: lg
-  tags: [lisp, repl, nrepl]
+  tags: [clojure, repl, nrepl]
 
 - name: Phel
   desc: Functional Lisp-inspired language compiling to PHP


### PR DESCRIPTION
Changed the tag from lisp to clojure: let-go is a Clojure implementation more than it is a Clojure-flavored lisp.