### PR TITLE
Update Phel description and tags in dialects.yaml

### DIFF
--- a/src/dialects.yaml
+++ b/src/dialects.yaml
@@ -206,14 +206,14 @@
   rtag: [repl, nrepl]
 
 - name: Phel
-  desc: Functional Lisp-inspired language compiling to PHP
+  desc: Functional Clojure-compatible Lisp compiling to PHP
   site: https://phel-lang.org/
   repo: https://github.com/phel-lang/phel-lang
   host: PHP
   fext: phel
-  ctag: [lisp]
-  atag: [jenshaase]
-  rtag: [repl]
+  ctag: [clojure]
+  atag: [chemaclass]
+  rtag: [repl, nrepl]
 
 - name: Basilisp
   desc: Clojure-compatible Lisp dialect with seamless Python interop


### PR DESCRIPTION
While marketing does not clearly state it, Phel is highly compatible with Clojure syntax including a jang-lang/clojure-test-suite in CI since couple months back. Active author/maintainer info also updated and nREPL mentioned (`phel nrepl`).